### PR TITLE
add object ProtocolMacAddress to represent special MAC addresses relativ...

### DIFF
--- a/netaddr/tests/2.x/eui/eui.txt
+++ b/netaddr/tests/2.x/eui/eui.txt
@@ -167,3 +167,29 @@ Sortability
 ('00-01-00-00-00-00-00-00', 64)
 
 }}}
+
+Special protocols
+
+
+Try to get a non registered protocol:
+
+{{{
+
+>>> eui = EUI('ff-00-00-00-00-00')
+>>> str(eui.protocol)
+'None'
+
+}}}
+
+But with a real protocol, we will get a ProtocolMacAddress object:
+
+{{{
+
+>>> eui = EUI('33-33-00-00-00-00')
+>>> eui.protocol
+ProtocolMacAddress('33-33-00-00-00-00')
+
+>>> eui.protocol.record
+{'pattern': '33-33', 'protocol': 'IPv6 Multicast'}
+
+}}}

--- a/netaddr/tests/3.x/eui/eui.txt
+++ b/netaddr/tests/3.x/eui/eui.txt
@@ -167,3 +167,29 @@ Sortability
 ('00-01-00-00-00-00-00-00', 64)
 
 }}}
+
+Special protocols
+
+
+Try to get a non registered protocol:
+
+{{{
+
+>>> eui = EUI('ff-00-00-00-00-00')
+>>> str(eui.protocol)
+'None'
+
+}}}
+
+But with a real protocol, we will get a ProtocolMacAddress object:
+
+{{{
+
+>>> eui = EUI('33-33-00-00-00-00')
+>>> eui.protocol
+ProtocolMacAddress('33-33-00-00-00-00')
+
+>>> eui.protocol.record
+{'pattern': '33-33', 'protocol': 'IPv6 Multicast'}
+
+}}}


### PR DESCRIPTION
Add object ProtocolMacAddress to represent special MAC addresses relative to some protocols.

Some MAC addresses are registered for some protocols, like broadcast, multicast. It should be great to know if a MAC address match one of those protocols.

