### PR TITLE
Handle eui64 addresses with colon as a delimiter and without delimeter.

### DIFF
--- a/netaddr/strategy/eui64.py
+++ b/netaddr/strategy/eui64.py
@@ -58,8 +58,11 @@ num_words = width // word_size
 max_word = 2 ** word_size - 1
 
 #: Compiled regular expression for detecting value EUI-64 identifiers.
-RE_EUI64_FORMAT = _re.compile('^' + '[:-]'.join(['([0-9A-F]{1,2})'] * 8) + '$',
-    _re.IGNORECASE)
+RE_EUI64_FORMATS = [
+    _re.compile('^' + ':'.join(['([0-9A-F]{1,2})'] * 8) + '$', _re.IGNORECASE),
+    _re.compile('^' + '-'.join(['([0-9A-F]{1,2})'] * 8) + '$', _re.IGNORECASE),
+    _re.compile('^' + '([0-9A-F]{1,2})' * 8 + '$', _re.IGNORECASE),
+]
 
 
 def valid_str(addr):
@@ -69,7 +72,11 @@ def valid_str(addr):
     :return: ``True`` if EUI-64 indentifier is valid, ``False`` otherwise.
     """
     try:
-        match_result = RE_EUI64_FORMAT.findall(addr)
+        match_result = [m[0] 
+            for m 
+            in [re.findall(addr) for re in RE_EUI64_FORMATS] 
+            if len(m) > 0
+        ]
         if len(match_result) != 0:
             return True
     except TypeError:
@@ -88,7 +95,12 @@ def str_to_int(addr):
     words = []
 
     try:
-        match_result = RE_EUI64_FORMAT.findall(addr)
+        match_result = [m[0] 
+            for m 
+            in [re.findall(addr) for re in RE_EUI64_FORMATS] 
+            if len(m) > 0
+        ]
+        import ipdb; ipdb.set_trace()
         if not match_result:
             raise TypeError
     except TypeError:

--- a/netaddr/strategy/eui64.py
+++ b/netaddr/strategy/eui64.py
@@ -100,7 +100,6 @@ def str_to_int(addr):
             in [re.findall(addr) for re in RE_EUI64_FORMATS] 
             if len(m) > 0
         ]
-        import ipdb; ipdb.set_trace()
         if not match_result:
             raise TypeError
     except TypeError:

--- a/netaddr/strategy/eui64.py
+++ b/netaddr/strategy/eui64.py
@@ -58,7 +58,7 @@ num_words = width // word_size
 max_word = 2 ** word_size - 1
 
 #: Compiled regular expression for detecting value EUI-64 identifiers.
-RE_EUI64_FORMAT = _re.compile('^' + '-'.join(['([0-9A-F]{1,2})'] * 8) + '$',
+RE_EUI64_FORMAT = _re.compile('^' + '[:-]'.join(['([0-9A-F]{1,2})'] * 8) + '$',
     _re.IGNORECASE)
 
 

--- a/netaddr/strategy/eui64.py
+++ b/netaddr/strategy/eui64.py
@@ -65,6 +65,15 @@ RE_EUI64_FORMATS = [
 ]
 
 
+def _get_match_result(address, formats):
+    return [
+        m[0] 
+        for m 
+        in [re.findall(address) for re in formats] 
+        if len(m) > 0
+    ]
+
+
 def valid_str(addr):
     """
     :param addr: An IEEE EUI-64 indentifier in string form.
@@ -72,11 +81,7 @@ def valid_str(addr):
     :return: ``True`` if EUI-64 indentifier is valid, ``False`` otherwise.
     """
     try:
-        match_result = [m[0] 
-            for m 
-            in [re.findall(addr) for re in RE_EUI64_FORMATS] 
-            if len(m) > 0
-        ]
+        match_result = _get_match_result(addr, RE_EUI64_FORMATS)
         if len(match_result) != 0:
             return True
     except TypeError:
@@ -95,11 +100,7 @@ def str_to_int(addr):
     words = []
 
     try:
-        match_result = [m[0] 
-            for m 
-            in [re.findall(addr) for re in RE_EUI64_FORMATS] 
-            if len(m) > 0
-        ]
+        match_result = _get_match_result(addr, RE_EUI64_FORMATS)
         if not match_result:
             raise TypeError
     except TypeError:

--- a/netaddr/tests/2.x/eui/eui64.txt
+++ b/netaddr/tests/2.x/eui/eui64.txt
@@ -69,3 +69,7 @@ IPAddress('1234::21b:77ff:fe49:54fd')
 >>> addr_colonned = EUI('00:1B:77:49:54:FD:BB:34')
 >>> addr_colonned
 EUI('00-1B-77-49-54-FD-BB-34')
+
+>>> addr_no_delimeter = EUI('001B774954FDBB34')
+>>> addr_no_delimeter
+EUI('00-1B-77-49-54-FD-BB-34')

--- a/netaddr/tests/2.x/eui/eui64.txt
+++ b/netaddr/tests/2.x/eui/eui64.txt
@@ -65,3 +65,7 @@ IPAddress('1234::21b:77ff:fe49:54fd')
 
 >>> eui.ipv6(0x12340000000000000000000000000000)
 IPAddress('1234::21b:77ff:fe49:54fd')
+
+>>> addr_colonned = EUI('00:1B:77:49:54:FD:BB:34')
+>>> addr_colonned
+EUI('00-1B-77-49-54-FD-BB-34')

--- a/netaddr/tests/3.x/eui/eui64.txt
+++ b/netaddr/tests/3.x/eui/eui64.txt
@@ -69,3 +69,7 @@ IPAddress('1234::21b:77ff:fe49:54fd')
 >>> addr_colonned = EUI('00:1B:77:49:54:FD:BB:34')
 >>> addr_colonned
 EUI('00-1B-77-49-54-FD-BB-34')
+
+>>> addr_no_delimeter = EUI('001B774954FDBB34')
+>>> addr_no_delimeter
+EUI('00-1B-77-49-54-FD-BB-34')

--- a/netaddr/tests/3.x/eui/eui64.txt
+++ b/netaddr/tests/3.x/eui/eui64.txt
@@ -65,3 +65,7 @@ IPAddress('1234::21b:77ff:fe49:54fd')
 
 >>> eui.ipv6(0x12340000000000000000000000000000)
 IPAddress('1234::21b:77ff:fe49:54fd')
+
+>>> addr_colonned = EUI('00:1B:77:49:54:FD:BB:34')
+>>> addr_colonned
+EUI('00-1B-77-49-54-FD-BB-34')


### PR DESCRIPTION
EUI-48 addresses can be supplied with colons or dashes as a delimiter. This PR gives the same possibility for EUI-64 addreses.