### PR TITLE
Add __slots__ definition to IPListMixin.

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -228,7 +228,6 @@ class BaseIP(object):
         return self._module.version
 
 
-
 class IPAddress(BaseIP):
     """
     An individual IPv4 or IPv6 address without a net mask or subnet prefix.
@@ -663,6 +662,7 @@ class IPListMixin(object):
     representing groups of IP addresses.
 
     """
+    __slots__ = ()
     def __iter__(self):
         """
         :return: An iterator providing access to all `IPAddress` objects

--- a/netaddr/tests/2.x/ip/constructor.txt
+++ b/netaddr/tests/2.x/ip/constructor.txt
@@ -232,3 +232,16 @@ Netmasks
 128
 
 }}}
+
+
+Class definition tests
+
+{{{
+
+>>> hasattr(IPNetwork("::/64"), "__dict__")
+False
+
+>>> hasattr(IPAddress("::"), "__dict__")
+False
+
+}}}


### PR DESCRIPTION
Removes `__dict__` from `IPNetwork`, which also defines `__slots__`.  It was accidentally picking up a dict via the IPListMixin.