### PR TITLE
fix IPAddress().netmask_bits to return 0 for 0.0.0.0 and [::] addresses

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -348,6 +348,11 @@ class IPAddress(BaseIP):
         if not self.is_netmask():
             return self._module.width
 
+        # the '0' address (e.g. 0.0.0.0 or 0000::) is a valid netmask with
+        # no bits set.
+        if self._value == 0:
+            return 0
+
         i_val = self._value
         numbits = 0
 

--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -403,6 +403,7 @@ def test_ipaddress_netmask_v4():
     assert IPAddress('1.1.1.1').netmask_bits() == 32
     assert IPAddress('255.255.255.254').netmask_bits() == 31
     assert IPAddress('255.255.255.0').netmask_bits() == 24
+    assert IPAddress('0.0.0.0').netmask_bits() == 0
 
 
 def test_ipaddress_hex_format():

--- a/netaddr/tests/ip/test_ip_v6.py
+++ b/netaddr/tests/ip/test_ip_v6.py
@@ -84,7 +84,7 @@ def test_ipnetwork_constructor_v6():
 
 
 def test_ipaddress_netmask_v6():
-    assert IPAddress('::').netmask_bits() == 128
+    assert IPAddress('::').netmask_bits() == 0
 
 
 def test_objects_use_slots():


### PR DESCRIPTION
Bug fix for issue #122 

To confirm:

```
$ sipcalc 0.0.0.0/0
-[ipv4 : 0.0.0.0/0] - 0

[CIDR]
Host address		- 0.0.0.0
Host address (decimal)	- 0
Host address (hex)	- 0
Network address		- 0.0.0.0
Network mask		- 0.0.0.0
Network mask (bits)	- 0
Network mask (hex)	- 0
Broadcast address	- 255.255.255.255
Cisco wildcard		- 255.255.255.255
Addresses in network	- 4294967295
Network range		- 0.0.0.0 - 255.255.255.255
Usable range		- 0.0.0.1 - 255.255.255.254
```

and

```
$ sipcalc ::/0
-[ipv6 : ::/0] - 0

[IPV6 INFO]
Expanded Address	- 0000:0000:0000:0000:0000:0000:0000:0000
Compressed address	- ::
Subnet prefix (masked)	- 0:0:0:0:0:0:0:0/0
Address ID (masked)	- 0:0:0:0:0:0:0:0/0
Prefix address		- 0:0:0:0:0:0:0:0
Prefix length		- 0
Address type		- Reserved
Comment			- Unspecified
Network range		- 0000:0000:0000:0000:0000:0000:0000:0000 -
			  ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
```

Note prefix length (a.k.a netmask bits) is 0. Which confirms what should be returned by `netmask_bits()`. There was an incorrect IPv6 testcase which I fixed.