### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A network address manipulation library for Python
 
 [![Circle CI](https://circleci.com/gh/drkjam/netaddr.png?style=shield)](https://circleci.com/gh/drkjam/netaddr) 
 [![Latest Version](https://img.shields.io/pypi/v/netaddr.svg)](https://pypi.python.org/pypi/netaddr)
-[![Documentation Status](https://readthedocs.org/projects/netaddr/badge/?version=latest)](http://netaddr.readthedocs.org/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/netaddr/badge/?version=latest)](https://netaddr.readthedocs.io/en/latest/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/netaddr.svg)](https://pypi.python.org/pypi/netaddr)
 
 Provides support for:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ netaddr 0.7.18 documentation
 .. image:: https://circleci.com/gh/drkjam/netaddr.png?style=shield
     :target: https://circleci.com/gh/drkjam/netaddr
 .. image:: https://readthedocs.org/projects/netaddr/badge/?version=latest
-    :target: https://netaddr.readthedocs.org/en/latest/
+    :target: https://netaddr.readthedocs.io/en/latest/
 .. image:: https://img.shields.io/pypi/dm/netaddr.svg
     :target: https://pypi.python.org/pypi/netaddr
 

--- a/release.py
+++ b/release.py
@@ -56,7 +56,7 @@ license = 'BSD License'
 long_description = """ .. image:: https://circleci.com/gh/drkjam/netaddr.png?style=shield
             :target: https://circleci.com/gh/drkjam/netaddr
         .. image:: https://readthedocs.org/projects/netaddr/badge/?version=latest
-            :target: https://netaddr.readthedocs.org/en/latest/
+            :target: https://netaddr.readthedocs.io/en/latest/
 
         Layer 3 addresses
         -----------------
@@ -82,7 +82,7 @@ long_description = """ .. image:: https://circleci.com/gh/drkjam/netaddr.png?sty
 
         For details on the latest changes and updates, see :-
 
-        https://netaddr.readthedocs.org/en/latest/changes.html
+        https://netaddr.readthedocs.io/en/latest/changes.html
 
         Requirements
         ------------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.