### PR TITLE
Fix IPNetwork.subnet doing unnecessary work

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -1274,7 +1274,7 @@ class IPNetwork(BaseIP, IPListMixin):
         i = 0
         while(i < count):
             subnet = self.__class__('%s/%d' % (base_subnet, prefixlen),
-                self._module.version)
+                False, self._module.version)
             subnet.value += (subnet.size * i)
             subnet.prefixlen = prefixlen
             i += 1


### PR DESCRIPTION
Missing implicit_prefix arg was causing unnecessary calls to
cidr_abbrev_to_verbose, when the prefix is already normalized. Was also
causing an unnecessary guess of the IP version. These make a difference
when expanding many items.