### PR TITLE
PEP 479: 'return' instead of 'raise StopIteration'.

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -1258,7 +1258,7 @@ class IPNetwork(BaseIP, IPListMixin):
 
         if not self.prefixlen <= prefixlen:
             #   Don't return anything.
-            raise StopIteration
+            return
 
         #   Calculate number of subnets to be returned.
         width = self._module.width


### PR DESCRIPTION
Raising StopIteration in generators is deprecated and will be converted to RuntimeError in Python3.7.
Instead of raising StopIteration the generator can be stopped by just a simple 'return' statement.

For details please visit https://www.python.org/dev/peps/pep-0479/