### PR TITLE
fix Python 3.8 SyntaxWarning on using `is not` with a string literal

### DIFF
--- a/netaddr/strategy/__init__.py
+++ b/netaddr/strategy/__init__.py
@@ -186,10 +186,9 @@ def int_to_bits(int_val, word_size, num_words, word_sep=''):
         bits = ('0' * word_size + bit_str)[-word_size:]
         bit_words.append(bits)
 
-    if word_sep is not '':
-        #   Check custom separator.
-        if not _is_str(word_sep):
-            raise ValueError('word separator is not a string: %r!' % word_sep)
+    if word_sep and not _is_str(word_sep):
+        # Check custom separator.
+        raise ValueError('word separator is not a string: %r!' % word_sep)
 
     return word_sep.join(bit_words)
 


### PR DESCRIPTION
Hello,

Python 3.8 was bugging me about netaddr using `is not` to compare a string. I simplified the condition a bit, it should work the same as before but without the warning.